### PR TITLE
Fix handling of int64/uint64 writes

### DIFF
--- a/packages/fsuipc/index.d.ts
+++ b/packages/fsuipc/index.d.ts
@@ -42,7 +42,7 @@ export enum Simulator {
 }
 
 type FixedSizedNumberType = Type.Byte|Type.SByte|Type.Int16|Type.Int32|Type.UInt16|Type.UInt32|Type.Double|Type.Single;
-type FixedSizedStringType = Type.Int64|Type.UInt64;
+type Int64Type = Type.Int64|Type.UInt64;
 type VariableSizedType = Type.ByteArray|Type.String|Type.BitArray;
 
 export class FSUIPC {
@@ -52,13 +52,14 @@ export class FSUIPC {
   close(): Promise<FSUIPC>;
   process(): Promise<object>;
 
-  add(name: string, offset: number, type: FixedSizedNumberType | FixedSizedStringType): Offset;
+  add(name: string, offset: number, type: FixedSizedNumberType | Int64Type): Offset;
   add(name: string, offset: number, type: VariableSizedType, length: number): Offset;
 
   remove(name: string): Offset;
 
-  write(offset: number, type: FixedSizedNumberType, value: number): void;
-  write(offset: number, type: FixedSizedStringType, value: string): void;
+  write(offset: number, type: FixedSizedNumberType | Int64Type, value: number): void;
+  write(offset: number, type: Int64Type, value: string): void;
+  write(offset: number, type: Int64Type, value: bigint): void;
 
   // Experimental
   write(offset: number, type: Type.String, length: number, value: string): void;

--- a/packages/fsuipc/src/FSUIPC.cc
+++ b/packages/fsuipc/src/FSUIPC.cc
@@ -313,19 +313,20 @@ void FSUIPC::Write(const Napi::CallbackInfo& info) {
     case Type::Int64: {
       int64_t x;
 
-      if (info[3].IsString()) {
+      if (info[2].IsString()) {
         std::string x_str =
-            std::string(info[3].As<Napi::String>().Utf8Value().c_str());
+            std::string(info[2].As<Napi::String>().Utf8Value().c_str());
         x = std::stoll(x_str);
-      } else if (info[3].IsNumber()) {
-        x = info[3].ToNumber().Int64Value();
-      } else if (info[3].IsBigInt()) {
+      } else if (info[2].IsNumber()) {
+        x = info[2].ToNumber().Int64Value();
+      } else if (info[2].IsBigInt()) {
         bool lossless = false;
-        x = info[3].As<Napi::BigInt>().Int64Value(&lossless);
+        x = info[2].As<Napi::BigInt>().Int64Value(&lossless);
       } else {
-        throw Napi::TypeError::New(env,
-                                   "FSUIPC.Write: expected fourth argument to "
-                                   "be a string or int when type is int64");
+        throw Napi::TypeError::New(
+            env,
+            "FSUIPC.Write: expected third argument to "
+            "be a string, int, or bigint when type is int64");
       }
 
       std::copy(
@@ -338,19 +339,20 @@ void FSUIPC::Write(const Napi::CallbackInfo& info) {
     case Type::UInt64: {
       uint64_t x;
 
-      if (info[3].IsString()) {
+      if (info[2].IsString()) {
         std::string x_str =
-            std::string(info[3].As<Napi::String>().Utf8Value().c_str());
+            std::string(info[2].As<Napi::String>().Utf8Value().c_str());
         x = std::stoll(x_str);
-      } else if (info[3].IsNumber()) {
-        x = info[3].ToNumber().Uint32Value();
-      } else if (info[3].IsBigInt()) {
+      } else if (info[2].IsNumber()) {
+        x = info[2].ToNumber().Uint32Value();
+      } else if (info[2].IsBigInt()) {
         bool lossless = false;
-        x = info[3].As<Napi::BigInt>().Uint64Value(&lossless);
+        x = info[2].As<Napi::BigInt>().Uint64Value(&lossless);
       } else {
-        throw Napi::TypeError::New(env,
-                                   "FSUIPC.Write: expected fourth argument to "
-                                   "be a string or int when type is uint64");
+        throw Napi::TypeError::New(
+            env,
+            "FSUIPC.Write: expected third argument to "
+            "be a string, int, or bigint when type is uint64");
       }
 
       std::copy(

--- a/packages/fsuipc/src/FSUIPC.cc
+++ b/packages/fsuipc/src/FSUIPC.cc
@@ -318,7 +318,7 @@ void FSUIPC::Write(const Napi::CallbackInfo& info) {
             std::string(info[3].As<Napi::String>().Utf8Value().c_str());
         x = std::stoll(x_str);
       } else if (info[3].IsNumber()) {
-        x = (int64_t)info[3].ToNumber().Int32Value();
+        x = (int64_t)info[3].ToNumber().Int64Value();
       } else {
         throw Napi::TypeError::New(env,
                                    "FSUIPC.Write: expected fourth argument to "

--- a/packages/fsuipc/src/FSUIPC.cc
+++ b/packages/fsuipc/src/FSUIPC.cc
@@ -318,7 +318,10 @@ void FSUIPC::Write(const Napi::CallbackInfo& info) {
             std::string(info[3].As<Napi::String>().Utf8Value().c_str());
         x = std::stoll(x_str);
       } else if (info[3].IsNumber()) {
-        x = (int64_t)info[3].ToNumber().Int64Value();
+        x = info[3].ToNumber().Int64Value();
+      } else if (info[3].IsBigInt()) {
+        bool lossless = false;
+        x = info[3].As<Napi::BigInt>().Int64Value(&lossless);
       } else {
         throw Napi::TypeError::New(env,
                                    "FSUIPC.Write: expected fourth argument to "
@@ -340,7 +343,10 @@ void FSUIPC::Write(const Napi::CallbackInfo& info) {
             std::string(info[3].As<Napi::String>().Utf8Value().c_str());
         x = std::stoll(x_str);
       } else if (info[3].IsNumber()) {
-        x = info[3].As<Napi::BigInt>().Uint64Value(false);
+        x = info[3].ToNumber().Uint32Value();
+      } else if (info[3].IsBigInt()) {
+        bool lossless = false;
+        x = info[3].As<Napi::BigInt>().Uint64Value(&lossless);
       } else {
         throw Napi::TypeError::New(env,
                                    "FSUIPC.Write: expected fourth argument to "

--- a/packages/fsuipc/src/FSUIPC.cc
+++ b/packages/fsuipc/src/FSUIPC.cc
@@ -340,7 +340,7 @@ void FSUIPC::Write(const Napi::CallbackInfo& info) {
             std::string(info[3].As<Napi::String>().Utf8Value().c_str());
         x = std::stoll(x_str);
       } else if (info[3].IsNumber()) {
-        x = (uint64_t)info[3].ToNumber().Uint32Value();
+        x = info[3].As<Napi::BigInt>().Uint64Value(false);
       } else {
         throw Napi::TypeError::New(env,
                                    "FSUIPC.Write: expected fourth argument to "


### PR DESCRIPTION
Based on changes from https://github.com/koesie10/fsuipc-node/pull/30, this fixes handling of int64/uint64 writes by allowing bigints and fixing the incorrect argument handling.