### PR TITLE
Fix 'no overloaded function' issues with vc17 complier

### DIFF
--- a/packages/fsuipc/src/FSUIPC.cc
+++ b/packages/fsuipc/src/FSUIPC.cc
@@ -69,7 +69,8 @@ Napi::Value FSUIPC::Open(const Napi::CallbackInfo& info) {
 Napi::Value FSUIPC::Close(const Napi::CallbackInfo& info) {
   Napi::Promise::Deferred deferred = Napi::Promise::Deferred::New(info.Env());
 
-  auto worker = new CloseAsyncWorker(info.Env(), deferred, this);
+  auto env = info.Env();
+  auto worker = new CloseAsyncWorker(env, deferred, this);
   worker->Queue();
 
   return deferred.Promise();
@@ -78,7 +79,8 @@ Napi::Value FSUIPC::Close(const Napi::CallbackInfo& info) {
 Napi::Value FSUIPC::Process(const Napi::CallbackInfo& info) {
   Napi::Promise::Deferred deferred = Napi::Promise::Deferred::New(info.Env());
 
-  auto worker = new ProcessAsyncWorker(info.Env(), deferred, this);
+  auto env = info.Env();
+  auto worker = new ProcessAsyncWorker(env, deferred, this);
   worker->Queue();
 
   return deferred.Promise();


### PR DESCRIPTION
The compiler with Visual Studio 2022 was not able to assert the type correctly, thus `node-gyp` throws `C2665` error when building the project into production:

```
FSUIPC::CloseAsyncWorker::CloseAsyncWorker': no overloaded function could convert all the argument types
FSUIPC::ProcessAsyncWorker::ProcessAsyncWorker': no overloaded function could convert all the argument types
```

This PR fixes the issue by assigning the method into an auto variable.